### PR TITLE
Expose browsedSubmolts in engagement state schema

### DIFF
--- a/agent-state.schema.json
+++ b/agent-state.schema.json
@@ -93,6 +93,14 @@
           "required": ["commentId", "at"]
         }
       }
+    },
+    "browsedSubmolts": {
+      "type": "object",
+      "description": "Submolts the agent has browsed. Keys are submolt names, values are ISO 8601 timestamps for the most recent browse.",
+      "additionalProperties": {
+        "type": "string",
+        "format": "date-time"
+      }
     }
   },
   "required": ["seen", "commented", "voted", "myPosts", "myComments"]

--- a/providers/state.js
+++ b/providers/state.js
@@ -12,7 +12,7 @@ export function loadState() {
   try {
     if (existsSync(STATE_FILE)) state = JSON.parse(readFileSync(STATE_FILE, "utf8"));
   } catch {}
-  if (!state) state = { seen: {}, commented: {}, voted: {}, myPosts: {}, myComments: {}, pendingComments: [] };
+  if (!state) state = { seen: {}, commented: {}, voted: {}, myPosts: {}, myComments: {}, browsedSubmolts: {}, pendingComments: [] };
   _stateCache = state;
   return state;
 }

--- a/providers/state.test.mjs
+++ b/providers/state.test.mjs
@@ -18,7 +18,7 @@ const { loadState, saveState, markSeen, markCommented, markVoted, unmarkVoted, m
 // state.js uses a module-level cache (_stateCache). We need to reset it between tests.
 // The only way to clear the cache is to save a fresh state, which sets _stateCache.
 function resetState() {
-  const fresh = { seen: {}, commented: {}, voted: {}, myPosts: {}, myComments: {}, pendingComments: [] };
+  const fresh = { seen: {}, commented: {}, voted: {}, myPosts: {}, myComments: {}, browsedSubmolts: {}, pendingComments: [] };
   saveState(fresh);
 }
 
@@ -39,6 +39,7 @@ describe('providers/state.js', () => {
       assert.deepStrictEqual(s.voted, {});
       assert.deepStrictEqual(s.myPosts, {});
       assert.deepStrictEqual(s.myComments, {});
+      assert.deepStrictEqual(s.browsedSubmolts, {});
       assert.deepStrictEqual(s.pendingComments, []);
     });
 
@@ -62,7 +63,7 @@ describe('providers/state.js', () => {
     it('creates state directory if missing', () => {
       const freshDir = join(TEST_HOME, '.config', 'moltbook2');
       // saveState always uses STATE_DIR from module, so we verify the existing dir works
-      saveState({ seen: {}, commented: {}, voted: {}, myPosts: {}, myComments: {}, pendingComments: [] });
+      saveState({ seen: {}, commented: {}, voted: {}, myPosts: {}, myComments: {}, browsedSubmolts: {}, pendingComments: [] });
       assert.ok(existsSync(STATE_DIR));
     });
   });


### PR DESCRIPTION
## Summary

This finishes the engagement-state tracking surface for `browsedSubmolts`:

- initializes `browsedSubmolts` in the default state object;
- includes it in `agent-state.schema.json` so exports/importers and external
  validators can recognize it;
- updates the state provider test fixture/default assertion.

The runtime tracking was already present via `markBrowsed()` and the
engagement/feed tools, so this PR keeps the schema/default state in sync with
that behavior.

## Verification

- `node --test providers/state.test.mjs` passes: 23 tests.

I also tried `npm test`, but the smoke suite expects a local service on
`127.0.0.1:3847`; with no service running, every endpoint fetch-failed before
reaching this change.