### PR TITLE
Add dry-run previews for Moltbook write tools

### DIFF
--- a/components/moltbook-core.js
+++ b/components/moltbook-core.js
@@ -218,7 +218,8 @@ export function register(server) {
     title: z.string().describe("Post title"),
     content: z.string().optional().describe("Post body text"),
     url: z.string().optional().describe("Link URL (for link posts)"),
-  }, async ({ submolt, title, content, url }) => {
+    dry_run: z.boolean().optional().describe("Preview the request without creating a post"),
+  }, async ({ submolt, title, content, url, dry_run }) => {
     if (title && title.length > MAX_POST_TITLE_LEN) title = title.slice(0, MAX_POST_TITLE_LEN) + "…";
     if (content && content.length > MAX_POST_CONTENT_LEN) content = content.slice(0, MAX_POST_CONTENT_LEN) + "\n\n[truncated]";
     const dk = dedupKey("post", submolt, title);
@@ -227,6 +228,15 @@ export function register(server) {
     const body = { submolt, title };
     if (content) body.content = content;
     if (url) body.url = url;
+    if (dry_run) {
+      return { content: [{ type: "text", text: JSON.stringify({
+        success: true,
+        dry_run: true,
+        action: "moltbook_post_create",
+        request: { method: "POST", path: "/posts", body },
+        warnings: outboundWarnings,
+      }, null, 2) }] };
+    }
     const data = await moltFetch("/posts", { method: "POST", body: JSON.stringify(body) });
     // Handle verification challenge if present
     const verifyResult = await solveVerification(data);
@@ -256,13 +266,23 @@ export function register(server) {
     post_id: z.string().describe("Post ID"),
     content: z.string().describe("Comment text"),
     parent_id: z.string().optional().describe("Parent comment ID for replies"),
-  }, async ({ post_id, content, parent_id }) => {
+    dry_run: z.boolean().optional().describe("Preview the request without posting a comment"),
+  }, async ({ post_id, content, parent_id, dry_run }) => {
     if (content && content.length > MAX_COMMENT_LEN) content = content.slice(0, MAX_COMMENT_LEN) + "\n\n[truncated]";
     const dk = dedupKey("comment", parent_id || post_id, content);
     if (isDuplicate(dk)) return { content: [{ type: "text", text: JSON.stringify({ success: false, error: "Duplicate comment blocked (same content within 2 minutes)" }) }] };
     const outboundWarnings = checkOutbound(content);
     const body = { content };
     if (parent_id) body.parent_id = parent_id;
+    if (dry_run) {
+      return { content: [{ type: "text", text: JSON.stringify({
+        success: true,
+        dry_run: true,
+        action: "moltbook_comment",
+        request: { method: "POST", path: `/posts/${post_id}/comments`, body },
+        warnings: outboundWarnings,
+      }, null, 2) }] };
+    }
     const data = await moltFetch(`/posts/${post_id}/comments`, { method: "POST", body: JSON.stringify(body) });
     // Handle verification challenge if present
     const verifyResult = await solveVerification(data);

--- a/components/moltbook-core.test.mjs
+++ b/components/moltbook-core.test.mjs
@@ -144,6 +144,12 @@ describe('moltbook-core.js component', () => {
           json: async () => ({ success: true, submolts: [{ name: 'general', display_name: 'General', subscriber_count: 100 }] })
         };
       }
+      if (url.includes('/posts') && opts?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({ success: true, post: { id: 'new-post-123' } })
+        };
+      }
       // Default: return error
       return {
         ok: false,
@@ -270,6 +276,46 @@ describe('moltbook-core.js component', () => {
       const result = await server.callTool('moltbook_submolts', {});
       const text = getText(result);
       assert.ok(text.includes('general') || text.includes('error'), 'Should list submolts or error');
+    });
+
+    test('moltbook_post_create dry_run previews request without API call', async () => {
+      global.fetch.mock.resetCalls();
+      const result = await server.callTool('moltbook_post_create', {
+        submolt: 'general',
+        title: 'Dry run title',
+        content: 'Dry run body',
+        dry_run: true
+      });
+      const data = JSON.parse(getText(result));
+      assert.equal(data.success, true);
+      assert.equal(data.dry_run, true);
+      assert.equal(data.action, 'moltbook_post_create');
+      assert.deepEqual(data.request, {
+        method: 'POST',
+        path: '/posts',
+        body: { submolt: 'general', title: 'Dry run title', content: 'Dry run body' }
+      });
+      assert.equal(global.fetch.mock.callCount(), 0);
+    });
+
+    test('moltbook_comment dry_run previews request without API call', async () => {
+      global.fetch.mock.resetCalls();
+      const result = await server.callTool('moltbook_comment', {
+        post_id: 'post-123',
+        content: 'Dry run comment',
+        parent_id: 'parent-456',
+        dry_run: true
+      });
+      const data = JSON.parse(getText(result));
+      assert.equal(data.success, true);
+      assert.equal(data.dry_run, true);
+      assert.equal(data.action, 'moltbook_comment');
+      assert.deepEqual(data.request, {
+        method: 'POST',
+        path: '/posts/post-123/comments',
+        body: { content: 'Dry run comment', parent_id: 'parent-456' }
+      });
+      assert.equal(global.fetch.mock.callCount(), 0);
     });
 
     test('moltbook_vote requires type and direction', async () => {


### PR DESCRIPTION
## Summary

- Adds optional `dry_run: true` support to `moltbook_post_create`.
- Adds optional `dry_run: true` support to `moltbook_comment`.
- Dry runs return the exact method, path, body, and outbound warnings without calling the Moltbook API or mutating duplicate/state tracking.

## Testing

- `node --test components/moltbook-core.test.mjs` passes: 27/27 tests.
- `npm test` currently fails in this checkout because the smoke suite expects a local API at `127.0.0.1:3847`; all smoke endpoint checks reported `fetch failed`.

Refs #6
